### PR TITLE
Remove print padding from poster

### DIFF
--- a/poster.pdf
+++ b/poster.pdf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30560ae7f6a33e634e4053c5bed1d7519bc7b7efb05a3ce892a474423daf5a43
-size 7260100
+oid sha256:b27f467fd3292ee0ae160303235b992acc55e44075f594735c03a6c2130b72ac
+size 7263150


### PR DESCRIPTION
While uploading the poster to https://postersession.ai/neurips19/ I noticed that we include the print margins in the online version. This removes the unnecessary whitespace.